### PR TITLE
chore: autopatch deps & CI hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,12 @@ on:
   schedule:
     - cron: '0 2 * * 0' # Semanal los domingos a las 2 AM
 
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   NODE_VERSION: '20.x'
   NPM_VERSION: '10.x'
@@ -23,12 +29,12 @@ jobs:
     
     steps:
     - name: Checkout código
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4 # TODO: pin SHA
       with:
         fetch-depth: 0
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v4 # TODO: pin SHA
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
@@ -56,10 +62,10 @@ jobs:
     
     steps:
     - name: Checkout código
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4 # TODO: pin SHA
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v4 # TODO: pin SHA
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
@@ -76,7 +82,7 @@ jobs:
       run: npm run test:coverage
 
     - name: Subir cobertura a Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4 # TODO: pin SHA
       with:
         file: ./coverage/lcov.info
         flags: unittests
@@ -91,10 +97,10 @@ jobs:
     
     steps:
     - name: Checkout código
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4 # TODO: pin SHA
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v4 # TODO: pin SHA
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
@@ -125,10 +131,10 @@ jobs:
     
     steps:
     - name: Checkout código
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4 # TODO: pin SHA
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v4 # TODO: pin SHA
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
@@ -143,8 +149,8 @@ jobs:
       run: npm run test:e2e
 
     - name: Subir reportes de Playwright
-      uses: actions/upload-artifact@v3
       if: always()
+      uses: actions/upload-artifact@v4 # TODO: pin SHA
       with:
         name: playwright-report
         path: |
@@ -162,10 +168,10 @@ jobs:
     
     steps:
     - name: Checkout código
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4 # TODO: pin SHA
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v4 # TODO: pin SHA
       with:
         node-version: ${{ env.NODE_VERSION }}
         cache: 'npm'
@@ -213,7 +219,7 @@ jobs:
       run: npm ci
 
     - name: Setup Pages
-      uses: actions/configure-pages@v4
+      uses: actions/configure-pages@v4 # TODO: pin SHA
 
     - name: Build para Pages
       run: |
@@ -228,13 +234,13 @@ jobs:
         cp LICENSE dist/
 
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v3 # TODO: pin SHA
       with:
         path: './dist'
 
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@v4 # TODO: pin SHA
 
   # Notificaciones
   notify:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,6 +8,12 @@ on:
   schedule:
     - cron: '30 1 * * 0'
 
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze code
@@ -24,19 +30,19 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4 # TODO: pin SHA
       with:
         fetch-depth: 0    # Necesario para CodeQL
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v3 # TODO: pin SHA
       with:
         languages: ${{ matrix.language }}
         setup: advanced
 
     - name: Set up Node.js (for JavaScript analysis)
       if: matrix.language == 'javascript'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v4 # TODO: pin SHA
       with:
         node-version: '18'
 
@@ -52,7 +58,7 @@ jobs:
 
     - name: Set up Python
       if: matrix.language == 'python'
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v4 # TODO: pin SHA
       with:
         python-version: '3.11'
 
@@ -67,10 +73,10 @@ jobs:
       run: pip install -e config
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v3 # TODO: pin SHA
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v3 # TODO: pin SHA
       with:
         output: results.sarif
         category: "/language:${{matrix.language}}"

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,12 @@ logs/
 dist/
 build/
 public/
+.turbo
+.next
+.pnpm-store/
+.yarn/
+.vercel/
+coverage*
 
 # **Archivos y Carpetas del Sistema Operativo**
 # macOS

--- a/REPORT.md
+++ b/REPORT.md
@@ -1,0 +1,19 @@
+# Informe de mantenimiento
+
+## Resumen
+- `npm ci` se ejecutó con advertencias de paquetes obsoletos.
+- `npm test` falló: vitest no encontrado.
+- `npm audit` falló con 403 Forbidden.
+- Se ampliaron exclusiones en `.gitignore`.
+- Workflows de GitHub Actions ahora incluyen `permissions: read-all`, `concurrency` y actualizaciones a `codecov-action@v4` y `upload-artifact@v4`.
+- Escaneo rápido de secretos: `api_keys_to_replace.txt` contiene claves revocadas (líneas 1-8).
+ - Se corrigió la indentación de pasos en `ci.yml` para evitar fallos en la canalización y se añadieron TODOs para fijar acciones por SHA.
+
+## Dependencias
+No se pudieron actualizar dependencias automáticamente (`npx npm-check-updates` devolvió 403 Forbidden).
+
+## Próximos pasos
+- Instalar `vitest` o revisar configuración de pruebas.
+- Revisar acceso al registry para ejecutar `npm audit` y `npm-check-updates`.
+- Considerar rotación adicional de claves listadas en `api_keys_to_replace.txt`.
+- Ejecutar `npx playwright install` para que las pruebas E2E encuentren los navegadores requeridos.


### PR DESCRIPTION
# Informe de mantenimiento

## Resumen
- `npm ci` se ejecutó con advertencias de paquetes obsoletos.
- `npm test` falló: vitest no encontrado.
- `npm audit` falló con 403 Forbidden.
- Se ampliaron exclusiones en `.gitignore`.
- Workflows de GitHub Actions ahora incluyen `permissions: read-all`, `concurrency` y actualizaciones a `codecov-action@v4` y `upload-artifact@v4`.
- Escaneo rápido de secretos: `api_keys_to_replace.txt` contiene claves revocadas (líneas 1-8).
- Se corrigió la indentación de pasos en `ci.yml` para evitar fallos en la canalización y se añadieron TODOs para fijar acciones por SHA.

## Dependencias
No se pudieron actualizar dependencias automáticamente (`npx npm-check-updates` devolvió 403 Forbidden).

## Próximos pasos
- Instalar `vitest` o revisar configuración de pruebas.
- Revisar acceso al registry para ejecutar `npm audit` y `npm-check-updates`.
- Considerar rotación adicional de claves listadas en `api_keys_to_replace.txt`.
- Ejecutar `npx playwright install` para que las pruebas E2E encuentren los navegadores requeridos.

------
https://chatgpt.com/codex/tasks/task_e_689964af35a883329c8969af9a80bb50